### PR TITLE
[release-1.3] apparmor: handle signal mediation (again)

### DIFF
--- a/contrib/apparmor/template_test.go
+++ b/contrib/apparmor/template_test.go
@@ -1,0 +1,18 @@
+// +build linux
+
+package apparmor
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCleanProfileName(t *testing.T) {
+	assert.Equal(t, cleanProfileName(""), "unconfined")
+	assert.Equal(t, cleanProfileName("unconfined"), "unconfined")
+	assert.Equal(t, cleanProfileName("unconfined (enforce)"), "unconfined")
+	assert.Equal(t, cleanProfileName("docker-default"), "docker-default")
+	assert.Equal(t, cleanProfileName("foo"), "foo")
+	assert.Equal(t, cleanProfileName("foo (enforce)"), "foo")
+}


### PR DESCRIPTION
Cherry-pick AppArmor fixes from containerd/containerd#4467

This was done in #8, but apparently got lost when @dweomer force-pushed some work to backport CVE fixes to the k3s-release/1.3 branch.

Related to: k3s-io/k3s#2778